### PR TITLE
Improve playlist parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,9 @@ fn parse_playlist(file: &str) -> Result<(), Box<dyn std::error::Error>> {
             continue; // its a comment; skip
         }
         line = line.replacen('~', &home, 1);
-        lines.push(line);
+        if File::open(&line).is_ok() {
+            lines.push(line); // file exists, therefore, push it onto the playlist
+        }
     }
     lines.shrink_to_fit();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,8 +51,8 @@ fn parse_playlist(file: &str) -> Result<(), Box<dyn std::error::Error>> {
             continue; // its a comment; skip
         }
         line = line.replacen('~', &home, 1);
-        if File::open(&line).is_ok() {
-            lines.push(line); // file exists, therefore, push it onto the playlist
+        if File::open(&line)?.metadata()?.permissions().readonly() {
+            lines.push(line);
         }
     }
     lines.shrink_to_fit();

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,10 @@ fn parse_playlist(file: &str) -> Result<(), Box<dyn std::error::Error>> {
     let home = std::env::var("HOME").unwrap_or_else(|_| String::new());
     for line in reader.lines() {
         let mut line = line.unwrap(); // tf
-        line = line.replacen('~', &home, 1);
         if line.starts_with("//") {
             continue; // its a comment; skip
         }
+        line = line.replacen('~', &home, 1);
         lines.push(line);
     }
     let _ = lines.pop(); // the last element is nothing, for some reason. get rid of it now.

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,8 +51,8 @@ fn parse_playlist(file: &str) -> Result<(), Box<dyn std::error::Error>> {
             continue; // its a comment; skip
         }
         line = line.replacen('~', &home, 1);
-        if File::open(&line)?.metadata()?.permissions().readonly() {
-            lines.push(line);
+        if File::open(&line).is_ok() {
+            lines.push(line); // file exists, therefore, push it onto the playlist
         }
     }
     lines.shrink_to_fit();

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,6 @@ fn parse_playlist(file: &str) -> Result<(), Box<dyn std::error::Error>> {
         line = line.replacen('~', &home, 1);
         lines.push(line);
     }
-    let _ = lines.pop(); // the last element is nothing, for some reason. get rid of it now.
     lines.shrink_to_fit();
 
     Ok(())


### PR DESCRIPTION
addresses the following problems:

- playlists without trailing EOF get truncated (introduced in f056ac08 at [line 48](https://github.com/WilliamAnimate/echotune/commit/f056ac08c3307796cf22e8d41ba48eb762aa7c57#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR48) when trying to fix a bug)
  because the above code is removed (one single .pop()), playlists with a trailing EOF now have an empty entry in the audio
- in order to mitigate, echotune now checks whether the file exists (or more accurately, if it can be accessed) in the first place