### PR TITLE
refactor receive system

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn quit_with(e: &str, s: &str) -> Result<std::convert::Infallible, Box<dyn std::
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use std::thread::{sleep, spawn};
+    use std::thread::spawn;
     use std::time::Duration;
     use echotune::SongControl::*;
 
@@ -163,7 +163,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut audio = song::Song::new();
     audio.play();
     loop {
-        let receive = mrx.try_recv();
+        let receive = mrx.recv_timeout(Duration::from_secs(1));
         if let Ok(k) = receive {
             match k {
                 DestroyAndExit => {
@@ -224,8 +224,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             VOLUME_LEVEL.store(audio.sink.volume(), Relaxed);
         }
-
-        sleep(Duration::from_millis(50));
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         tui.enter_alt_buffer().unwrap();
         loop {
             tui.tick();
-            let receive = rrx.try_recv();
+            let receive = rrx.recv_timeout(Duration::from_secs(1));
             if let Ok(k) = receive {
                 match k {
                     DestroyAndExit => break, // the destructor will exit the alt buffer
@@ -125,7 +125,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 };
             }
-            sleep(Duration::from_millis(50));
         }
     });
 


### PR DESCRIPTION
what echotune was initially doing prior to this pull request (and _branch_ of development (hehe)) was that it was handling receives EVERY 50 milliseconds. it was the easiest solution i could think of then.

this causes a bit of problems, including forced 50ms input delay in echotune ^0.1.0 versions. this is most noticeable when using the scrollwheel to adjust volume[^1], and has been mostly mitigated in this branch.

# ALL'S NOT LOST!

with a bit of timeout magic by rust, we dont have to busy-wait, therefore making echotune more green:tm:.

best part? it needs minimal code changes.

[^1]: as of ^0.1.0, (and this pr branch), echotune uses the the up and down arrows to adjust volume. this is subject to change.