### PR TITLE
accept multiple media files as arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
         echotune::FileFormat::Audio => {
             let mut lines = PLAYLIST.write().unwrap();
-            render_requested_mode = echotune::RenderMode::Safe; // only one song, so do minimal
-            lines.push(file.to_string());
+            if args.len() > 2 {
+                for s in args.iter()
+                    .skip(1) // the first index is echotune itself
+                    .by_ref() // then actually iterate through it
+                {
+                    lines.push(s.to_owned());
+                }
+            } else {
+                render_requested_mode = echotune::RenderMode::Safe; // only one song, so do minimal
+                lines.push(file.to_string());
+            }
         },
     };
 


### PR DESCRIPTION
echotune will use playlist mode if that is the case.

usage (with fish shell):

`./echotune ./path-to-folder-with-audio/*`

eventually maybe this won't be shell dependent, where the shell would expand the arguments because of the `*`.
