### PR TITLE
update input system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,11 +215,11 @@ name = "echotune"
 version = "0.1.0-rc3"
 dependencies = [
  "basic-toml",
+ "getch-rs",
  "lazy_static",
  "rodio",
  "serde",
  "terminal_size",
- "termios",
 ]
 
 [[package]]
@@ -242,6 +242,17 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "getch-rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "204438a76b37cc69e075ac91fd79b2d2bab9f3c9038fe6869faaab19806f6e00"
+dependencies = [
+ "libc",
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -382,6 +393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +450,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -520,6 +553,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -679,15 +718,6 @@ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ lazy_static = "1.5.0"
 rodio = { path = "./echotune-rodio", default-features = false, features = ["minimp3", "flac", "vorbis", "wav"] }
 serde = { version = "1.0.210", optional = true, features = ["serde_derive"] }
 terminal_size = { version = "0.3.0", default-features = false }
-termios = "0.3.3"
 
 [profile.dev.package."*"]
 opt-level = 'z'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 basic-toml = { version = "0.1.9", optional = true }
+getch-rs = "=0.2.0"
 lazy_static = "1.5.0"
 rodio = { path = "./echotune-rodio", default-features = false, features = ["minimp3", "flac", "vorbis", "wav"] }
 serde = { version = "1.0.210", optional = true, features = ["serde_derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     let _input = spawn(move || {
-        let mut input = input::Input::from_nothing_and_apply();
+        let input = input::Input::from_nothing_and_apply();
         loop {
             let i = input.blocking_wait_for_input();
             match i {


### PR DESCRIPTION
this PR should bring windows support to echotune, by not depending on the unix-specific `std::os::unix::AsRawFd` function call. At the very least, it should compile.