### PR TITLE
fix: encore slow to close, if mpris is enabled on linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = encore-rodio
 	url = https://github.com/williamanimate/rodio-iwantthetotalduration
 	branch = upstream_stable
+[submodule "encore-souvlaki"]
+	path = encore-souvlaki
+	url = https://github.com/WilliamAnimate/encore-souvlaki.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,8 +1040,6 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "souvlaki"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aa340f1288ab99c588241162942ad8fda9ceea7bc805156dc6b2318823351c"
 dependencies = [
  "base64",
  "block",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.210", optional = true, features = ["serde_derive"] }
 # or you can trade binary size for memory leaks by using `minimp3` instead.
 rodio = { path = "./encore-rodio", default-features = false, features = ["mp3", "flac", "vorbis", "wav"] }
 dhat = { version = "0.3.3", optional = true }
-souvlaki = { version = "0.8.0", optional = true }
+souvlaki = { path = "./encore-souvlaki", optional = true }
 
 [profile.dev]
 incremental = true


### PR DESCRIPTION
gah, another submodule